### PR TITLE
Can get multi image on Android 10

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,9 +38,9 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.2.1'
 
-    // rxjava
-    implementation "io.reactivex.rxjava2:rxjava:2.2.0"
-    implementation "io.reactivex.rxjava2:rxandroid:2.0.2"
+    // rx
+    implementation "io.reactivex.rxjava2:rxkotlin:2.4.0"
+    implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0'

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/base/BaseKotlinViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/base/BaseKotlinViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import com.tistory.deque.previewmaker.kotlin.util.SingleLiveEvent
 import com.tistory.deque.previewmaker.kotlin.util.SnackbarMessage
 import com.tistory.deque.previewmaker.kotlin.util.SnackbarMessageString
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.disposables.Disposable
 
 open class BaseKotlinViewModel : ViewModel() {
 
@@ -17,23 +19,20 @@ open class BaseKotlinViewModel : ViewModel() {
     val startLoadingDialogEvent: LiveData<Any> get() = _startLoadingDialogEvent
     private val _stopLoadingDialogEvent: SingleLiveEvent<Any> = SingleLiveEvent()
     val stopLoadingDialogEvent: LiveData<Any> get() = _stopLoadingDialogEvent
-/*
 
-    */
     /**
      * RxJava 의 observing을 위한 부분.
      * addDisposable을 이용하여 추가하기만 하면 된다
-     *//*
-
+     */
     private val compositeDisposable = CompositeDisposable()
 
     fun addDisposable(disposable: Disposable) {
         compositeDisposable.add(disposable)
     }
-*/
+
 
     override fun onCleared() {
-        //compositeDisposable.clear()
+        compositeDisposable.clear()
         super.onCleared()
     }
 

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/Preview.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/Preview.kt
@@ -15,8 +15,9 @@ import java.util.*
 
 data class Preview(
         var originalImageUri: Uri, // 원래 이미지의 Uri. 그런데 저장이나 crop을 하면 바뀐 저장이 된 파일의 uri로 바뀜
-        var thumbnailImageUri: Uri,
+        var thumbnailImageUri: Uri? = null,
         var resultImageUri: Uri, // 저장 할 이미지의 Uri. 저장이나 crop을 최소 한번이라도 하면 쓸모 없어짐. 즉, 최초 저장할때만 쓸모있음.
+        var thumbnailBitmap: Bitmap? = null, // 썸네일용 비트맵
         var isSaved: Boolean,
 
         var _brightness: Int,
@@ -47,9 +48,9 @@ data class Preview(
         }
     }
 
-    constructor(originalImageURI: Uri, thumbnailImageURI: Uri, rotation: Int) :
-            this(originalImageURI, thumbnailImageURI, makeResultImageFile(), true,
-                    0, 0, 0, 0) {
+    constructor(originalImageUri: Uri, thumbnailImageURI: Uri?, thumbnailBitmap: Bitmap?, rotation: Int) :
+            this(originalImageUri, thumbnailImageURI, makeResultImageFile(), thumbnailBitmap,
+                    true, 0, 0, 0, 0) {
         this.rotation = rotation
     }
 

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewListModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewListModel.kt
@@ -1,6 +1,6 @@
 package com.tistory.deque.previewmaker.kotlin.model
 
-class PreviewListModel() {
+class PreviewListModel {
 
     var previewArrayList: ArrayList<Preview> = ArrayList()
 

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
@@ -34,7 +34,7 @@ class PreviewLoader(private val context: Context) {
     private val compositeDisposable = CompositeDisposable()
 
     private val thumbnailBitmapSize: Int = context.resources.run {
-        (getDimension(R.dimen.thumbnail_item_image_width_height) * displayMetrics.density).toInt() * 100
+        (getDimension(R.dimen.thumbnail_item_image_width_height) * displayMetrics.density).toInt()
     }
 
     val previewSubject: ReplaySubject<Preview> = ReplaySubject.create()

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
@@ -1,0 +1,123 @@
+package com.tistory.deque.previewmaker.kotlin.model
+
+import android.content.Context
+import android.database.CursorIndexOutOfBoundsException
+import android.graphics.Bitmap
+import android.media.ExifInterface
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.util.Size
+import androidx.annotation.RequiresApi
+import com.tistory.deque.previewmaker.kotlin.util.EzLogger
+import com.tistory.deque.previewmaker.kotlin.util.extension.getUri
+import io.reactivex.Single
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.rxkotlin.subscribeBy
+import io.reactivex.schedulers.Schedulers
+import io.reactivex.subjects.ReplaySubject
+import java.io.File
+import java.io.FileNotFoundException
+
+class PreviewLoader(private val context: Context) {
+
+    companion object{
+        const val THUMBNAIL_MAKE_METHOD_CALL_COUNT_MAX = 3
+    }
+
+    private val compositeDisposable = CompositeDisposable()
+
+    val previewSubject: ReplaySubject<Preview> = ReplaySubject.create()
+
+    private fun makePreviewSingle(previewPath: String): Single<Preview> {
+        return Single.fromCallable {
+            var thumbnailBitmap: Bitmap? = null
+            var thumbnailUri: Uri? = null
+            val originalUri: Uri = Uri.fromFile(File(previewPath))
+            if (Build.VERSION.SDK_INT  >= Build.VERSION_CODES.Q) {
+                thumbnailBitmap = getThumbnailBitmapFromOriginalUri(context, previewPath)
+            } else {
+                thumbnailUri = getThumbnailUriFromOriginalUri(context, previewPath) ?: originalUri
+            }
+            val rotation = try {
+                ExifInterface(previewPath)
+                        .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+            } catch (e: FileNotFoundException) {
+                ExifInterface.ORIENTATION_UNDEFINED
+            }
+
+            return@fromCallable Preview(originalUri, thumbnailUri, thumbnailBitmap, rotation)
+        }
+    }
+
+    fun destroy() {
+        compositeDisposable.clear()
+    }
+
+    fun startLoadPreview(previewPathList: ArrayList<String>) {
+        previewPathList.forEach { previewPath ->
+            compositeDisposable.add(makePreviewSingle(previewPath)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribeBy (
+                            onSuccess = {
+                                previewSubject.onNext(it)
+                                EzLogger.d("Thumbnail parsing success : $it")
+                            },
+                            onError = {
+                                EzLogger.d("Load preview error : $previewPath")
+                            }
+                    ))
+        }
+        previewSubject.onComplete()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun getThumbnailBitmapFromOriginalUri(context: Context, imagePath: String): Bitmap? {
+        EzLogger.d("imagePath : $imagePath")
+        val imageUri = imagePath.getUri(context.contentResolver) ?: return null
+        EzLogger.d("original imageUri : $imageUri")
+        val contentResolver = context.contentResolver
+        return contentResolver.loadThumbnail(imageUri, Size(100, 100), null)
+    }
+
+    private fun getThumbnailUriFromOriginalUri(context: Context, imagePath: String): Uri? {
+        EzLogger.d("imagePath : $imagePath")
+
+        val selectedImageUri = imagePath.getUri(context.contentResolver) ?: return null
+        val rowId = (selectedImageUri.lastPathSegment) ?: return null
+        val rowIdLong: Long = rowId.toLongOrNull() ?: return null
+
+        EzLogger.d("original uri : $selectedImageUri , row ID : $rowIdLong")
+
+        return imageIdToThumbnail(context, rowIdLong, 0)
+    }
+
+    private fun imageIdToThumbnail(context: Context, imageId: Long, callCount: Int): Uri? {
+        if (callCount >= THUMBNAIL_MAKE_METHOD_CALL_COUNT_MAX) return null
+
+        val projection = arrayOf(MediaStore.Images.Thumbnails.DATA)
+        val contentResolver = context.contentResolver
+
+        try {
+            contentResolver.query(
+                    MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI,
+                    projection,
+                    MediaStore.Images.Thumbnails.IMAGE_ID + "=?",
+                    arrayOf(imageId.toString()),
+                    null)
+                    ?.use { thumbnailCursor ->
+                        return if (thumbnailCursor.moveToFirst()) {
+                            Uri.parse(thumbnailCursor.getString(thumbnailCursor.getColumnIndex(projection[0])))
+                        } else {
+                            MediaStore.Images.Thumbnails.getThumbnail(contentResolver, imageId, MediaStore.Images.Thumbnails.MINI_KIND, null)
+                            //EzLogger.d("No exist thumbnail, so make it")
+                            imageIdToThumbnail(context, imageId, callCount + 1)
+                        }
+                    } ?: return null
+        } catch (e: CursorIndexOutOfBoundsException) {
+            return null
+        }
+    }
+}

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
@@ -97,14 +97,12 @@ class KtPreviewEditActivity : BaseKotlinActivity<KtPreviewEditViewModel>() {
                 }
             }
         })
-        viewModel.loadingFinishEachThumbnailEvent.observe(this, Observer { position ->
-            position?.let {
-                EzLogger.d("loadingFinishEachThumbnailEvent observe position : $position")
-                previewThumbnailAdapter.notifyDataSetChanged()
-                preview_edit_thumbnail_loading_progress_bar.run { post { progress = position } }
-            }
+        viewModel.loadingFinishEachThumbnailEvent.observe(this, Observer {
+            EzLogger.d("loadingFinishEachThumbnailEvent observe")
+            previewThumbnailAdapter.notifyDataSetChanged()
+            preview_edit_thumbnail_loading_progress_bar.run { post { ++progress } }
         })
-        viewModel.finishLoadingThumbnailEvent.observe(this, Observer { size ->
+        viewModel.finishLoadingThumbnailEvent.observe(this, Observer {
             previewThumbnailAdapter.notifyDataSetChanged()
             preview_edit_thumbnail_loading_progress_bar.run { post { visibility = View.GONE } }
         })
@@ -137,7 +135,8 @@ class KtPreviewEditActivity : BaseKotlinActivity<KtPreviewEditViewModel>() {
     }
 
     override fun initViewFinal() {
-        viewModel.makePreviewThumbnail(applicationContext, previewPathList)
+        //viewModel.makePreviewThumbnail(applicationContext, previewPathList)
+        viewModel.loadPreviewThumbnail(applicationContext, previewPathList)
     }
 
     override fun onBackPressed() {
@@ -170,6 +169,7 @@ class KtPreviewEditActivity : BaseKotlinActivity<KtPreviewEditViewModel>() {
         } else {
             EzLogger.d("cropCancel")
         }
+        super.onActivityResult(requestCode, resultCode, data)
     }
 
     private fun mainLoadingProgressBarStart() {

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -29,6 +29,7 @@ import com.yalantis.ucrop.view.CropImageView
 import io.reactivex.rxkotlin.subscribeBy
 import java.io.File
 import java.io.FileNotFoundException
+import java.util.concurrent.TimeUnit
 
 class KtPreviewEditViewModel : BaseKotlinViewModel() {
     private val _startLoadingThumbnailEvent = SingleLiveEvent<Int>()

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -17,6 +17,7 @@ import com.tistory.deque.previewmaker.kotlin.manager.PreviewBitmapManager
 import com.tistory.deque.previewmaker.kotlin.manager.PreviewEditButtonViewStateManager
 import com.tistory.deque.previewmaker.kotlin.model.Preview
 import com.tistory.deque.previewmaker.kotlin.model.PreviewListModel
+import com.tistory.deque.previewmaker.kotlin.model.PreviewLoader
 import com.tistory.deque.previewmaker.kotlin.model.Stamp
 import com.tistory.deque.previewmaker.kotlin.util.EtcConstant
 import com.tistory.deque.previewmaker.kotlin.util.EzLogger
@@ -25,6 +26,7 @@ import com.tistory.deque.previewmaker.kotlin.util.extension.getUri
 import com.yalantis.ucrop.UCrop
 import com.yalantis.ucrop.model.AspectRatio
 import com.yalantis.ucrop.view.CropImageView
+import io.reactivex.rxkotlin.subscribeBy
 import java.io.File
 import java.io.FileNotFoundException
 
@@ -35,11 +37,11 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
     private val _previewThumbnailAdapterNotifyDataSet = SingleLiveEvent<Any>()
     val previewThumbnailAdapterNotifyDataSet: LiveData<Any> get() = _previewThumbnailAdapterNotifyDataSet
 
-    private val _loadingFinishEachThumbnailEvent = SingleLiveEvent<Int>()
-    val loadingFinishEachThumbnailEvent: LiveData<Int> get() = _loadingFinishEachThumbnailEvent
+    private val _loadingFinishEachThumbnailEvent = SingleLiveEvent<Unit>()
+    val loadingFinishEachThumbnailEvent: LiveData<Unit> get() = _loadingFinishEachThumbnailEvent
 
-    private val _finishLoadingThumbnailEvent = SingleLiveEvent<Int>()
-    val finishLoadingThumbnailEvent: LiveData<Int> get() = _finishLoadingThumbnailEvent
+    private val _finishLoadingThumbnailEvent = SingleLiveEvent<Unit>()
+    val finishLoadingThumbnailEvent: LiveData<Unit> get() = _finishLoadingThumbnailEvent
 
     private val _startLoadingPreviewToCanvas = SingleLiveEvent<Any>()
     val startLoadingPreviewToCanvas: LiveData<Any> get() = _startLoadingPreviewToCanvas
@@ -60,16 +62,19 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
     val startSavePreviewEvent: LiveData<Any> get() = _startSavePreviewEvent
 
     var previewListModel: PreviewListModel = PreviewListModel()
-    private val previewListSize: Int
-        get() = previewPathList.size
-
-    var previewPathList = ArrayList<String>()
 
     var selectedPreview: Preview? = null
     var selectedPreviewPosition: Int? = null
     var stamp: Stamp? = null
 
     var dbOpenHelper: KtDbOpenHelper? = null
+
+    final var previewLoader: PreviewLoader? = null
+
+    override fun onCleared() {
+        previewLoader?.destroy()
+        super.onCleared()
+    }
 
     fun dbOpen(context: Context) {
         EzLogger.d("main activity : db open")
@@ -89,17 +94,6 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
                 showSnackbar(R.string.snackbar_stamp_not_found)
             }
         }
-    }
-
-    fun makePreviewThumbnail(context: Context, previewPathList: ArrayList<String>) {
-        EzLogger.d("makePreviewThumbnail")
-
-        this.previewPathList = previewPathList
-
-        _startLoadingThumbnailEvent.value = previewListSize
-        val addPreviewThumbnailAsyncTask = AddPreviewThumbnailAsyncTask(context)
-        addPreviewThumbnailAsyncTask.execute()
-
     }
 
     private fun thumbnailUriFromOriginalUri(context: Context, imagePath: String): Uri? {
@@ -137,14 +131,6 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
         } catch (e: CursorIndexOutOfBoundsException) {
             return null
         }
-    }
-
-    private fun loadingFinishEachThumbnail(position: Int) {
-        _loadingFinishEachThumbnailEvent.value = position
-    }
-
-    private fun loadingFinishAllThumbnail(allThumbnailSize: Int) {
-        _finishLoadingThumbnailEvent.value = allThumbnailSize
     }
 
     private fun initCanvasAndPreview(preview: Preview) {
@@ -200,7 +186,6 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
         if (previewListModel.size <= 1) return
         selectedPreviewPosition?.let {
             previewListModel.delete(it)
-            previewPathList.removeAt(it)
             //_previewThumbnailAdapterRemovePosition.value = it
             _previewThumbnailAdapterNotifyDataSet.call()
 
@@ -277,53 +262,25 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
         showSnackbar("저장 완료\n저장 경로:${EtcConstant.PREVIEW_SAVED_DIRECTORY}/$fileName")
     }
 
-    inner class AddPreviewThumbnailAsyncTask(val context: Context) : AsyncTask<Void, Int, Int>() {
+    fun loadPreviewThumbnail(applicationContext: Context, previewPathList: java.util.ArrayList<String>) {
+        _startLoadingThumbnailEvent.value = previewPathList.size
 
-        private var loadingCounter = 0
-
-        override fun onPreExecute() {
-            super.onPreExecute()
-            previewListModel.initPreviewList()
-            _previewThumbnailAdapterNotifyDataSet.call()
+        previewLoader = PreviewLoader(applicationContext)
+        previewLoader?.let { loader ->
+            addDisposable(loader.previewSubject.subscribeBy(
+                    onNext = {
+                        previewListModel.addPreview(it)
+                        _loadingFinishEachThumbnailEvent.call()
+                    },
+                    onError = {
+                        EzLogger.d("preview subject error : $it")
+                    },
+                    onComplete = {
+                        _finishLoadingThumbnailEvent.call()
+                    }
+            ))
+            loader.startLoadPreview(previewPathList)
         }
-
-        override fun doInBackground(vararg params: Void?): Int {
-            previewPathList.forEach { previewPath ->
-                EzLogger.d("doInBackground... preview path : $previewPath, make thumbnailUri...")
-                val originalUri: Uri = Uri.fromFile(File(previewPath))
-                val thumbnailUri: Uri = thumbnailUriFromOriginalUri(context, previewPath)
-                        ?: originalUri
-
-                EzLogger.d("Thumbnail parsing success : $thumbnailUri")
-
-                val rotation = try {
-                    ExifInterface(previewPath)
-                            .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
-                } catch (e: FileNotFoundException) {
-                    ExifInterface.ORIENTATION_UNDEFINED
-                }
-
-                val preview = Preview(originalUri, thumbnailUri, rotation)
-                previewListModel.addPreview(preview)
-
-                publishProgress(loadingCounter)
-                loadingCounter++
-            }
-            return loadingCounter
-        }
-
-        override fun onProgressUpdate(vararg values: Int?) {
-            super.onProgressUpdate(*values)
-            values[0]?.let {
-                loadingFinishEachThumbnail(it)
-            }
-        }
-
-        override fun onPostExecute(allThumbnailSize: Int) {
-            super.onPostExecute(allThumbnailSize)
-            loadingFinishAllThumbnail(allThumbnailSize)
-        }
-
     }
 
     inner class LoadingPreviewToCanvas(val context: Context, val preview: Preview) : AsyncTask<Void, Void, Preview>() {

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.tistory.deque.previewmaker.R
 import com.tistory.deque.previewmaker.kotlin.model.Preview
+import com.tistory.deque.previewmaker.kotlin.util.EzLogger
 import kotlinx.android.synthetic.main.kt_preview_thumbnail_item.view.*
 
 class PreviewThumbnailHolder(parent:ViewGroup): RecyclerView.ViewHolder(
@@ -15,14 +16,14 @@ class PreviewThumbnailHolder(parent:ViewGroup): RecyclerView.ViewHolder(
 ){
     fun onBind(item: Preview, position: Int, previewThumbnailClickListener: (Preview, Int) -> Unit) {
         itemView.run {
-            when (item.rotation) {
-                ExifInterface.ORIENTATION_ROTATE_90 -> preview_thumbnail_item_image_view.rotation = 90f
-                ExifInterface.ORIENTATION_ROTATE_180 -> preview_thumbnail_item_image_view.rotation = 180f
-                ExifInterface.ORIENTATION_ROTATE_270 -> preview_thumbnail_item_image_view.rotation = 270f
-            }
             item.thumbnailBitmap?.let {
                 preview_thumbnail_item_image_view.setImageBitmap(it)
             } ?: run {
+                when (item.rotation) {
+                    ExifInterface.ORIENTATION_ROTATE_90 -> preview_thumbnail_item_image_view.rotation = 90f
+                    ExifInterface.ORIENTATION_ROTATE_180 -> preview_thumbnail_item_image_view.rotation = 180f
+                    ExifInterface.ORIENTATION_ROTATE_270 -> preview_thumbnail_item_image_view.rotation = 270f
+                }
                 preview_thumbnail_item_image_view.setImageURI(item.thumbnailImageUri ?: return@onBind)
             }
             preview_thumbnail_item_layout.setOnClickListener {

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
@@ -15,7 +15,11 @@ class PreviewThumbnailHolder(parent:ViewGroup): RecyclerView.ViewHolder(
 ){
     fun onBind(item: Preview, position: Int, previewThumbnailClickListener: (Preview, Int) -> Unit) {
         itemView.run {
-            preview_thumbnail_item_image_view.setImageURI(item.thumbnailImageUri)
+            item.thumbnailBitmap?.let {
+                preview_thumbnail_item_image_view.setImageBitmap(it)
+            } ?: run {
+                preview_thumbnail_item_image_view.setImageURI(item.thumbnailImageUri ?: return@onBind)
+            }
             when (item.rotation) {
                 ExifInterface.ORIENTATION_ROTATE_90 -> preview_thumbnail_item_image_view.rotation = 90f
                 ExifInterface.ORIENTATION_ROTATE_180 -> preview_thumbnail_item_image_view.rotation = 180f

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
@@ -15,15 +15,15 @@ class PreviewThumbnailHolder(parent:ViewGroup): RecyclerView.ViewHolder(
 ){
     fun onBind(item: Preview, position: Int, previewThumbnailClickListener: (Preview, Int) -> Unit) {
         itemView.run {
-            item.thumbnailBitmap?.let {
-                preview_thumbnail_item_image_view.setImageBitmap(it)
-            } ?: run {
-                preview_thumbnail_item_image_view.setImageURI(item.thumbnailImageUri ?: return@onBind)
-            }
             when (item.rotation) {
                 ExifInterface.ORIENTATION_ROTATE_90 -> preview_thumbnail_item_image_view.rotation = 90f
                 ExifInterface.ORIENTATION_ROTATE_180 -> preview_thumbnail_item_image_view.rotation = 180f
                 ExifInterface.ORIENTATION_ROTATE_270 -> preview_thumbnail_item_image_view.rotation = 270f
+            }
+            item.thumbnailBitmap?.let {
+                preview_thumbnail_item_image_view.setImageBitmap(it)
+            } ?: run {
+                preview_thumbnail_item_image_view.setImageURI(item.thumbnailImageUri ?: return@onBind)
             }
             preview_thumbnail_item_layout.setOnClickListener {
                 previewThumbnailClickListener(item, position)

--- a/app/src/main/res/layout/kt_preview_thumbnail_item.xml
+++ b/app/src/main/res/layout/kt_preview_thumbnail_item.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="90dp"
-    android:layout_height="90dp"
-    android:layout_marginTop="8dp"
-    android:layout_marginEnd="8dp"
-    android:layout_marginBottom="8dp">
+    android:layout_width="@dimen/thumbnail_item_image_width_height"
+    android:layout_height="@dimen/thumbnail_item_image_width_height"
+    android:layout_marginTop="@dimen/thumbnail_item_image_margin"
+    android:layout_marginEnd="@dimen/thumbnail_item_image_margin"
+    android:layout_marginBottom="@dimen/thumbnail_item_image_margin">
 
     <FrameLayout
         android:layout_width="match_parent"
@@ -15,7 +15,6 @@
             android:id="@+id/preview_thumbnail_item_image_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_weight="1"
             android:scaleType="centerCrop"
             app:srcCompat="@color/white" />
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -5,4 +5,7 @@
   <dimen name="nav_header_vertical_spacing">8dp</dimen>
   <dimen name="nav_header_height">176dp</dimen>
   <dimen name="fab_margin">16dp</dimen>
+
+  <dimen name="thumbnail_item_image_width_height">90dp</dimen>
+  <dimen name="thumbnail_item_image_margin">8dp</dimen>
 </resources>


### PR DESCRIPTION
### 변경사항
1. 안드로이드10에서 멀티이미지를 불러오지 못하던 문제 해결
    * 원인 : thumbnail을 로드하는 방식이 변화함 (contentResolver.loadThumbnail 를 사용해야함)
    * 해결 : contentResolver.loadThumbnail를 이용
    * 참고사항 : contentResolver.loadThumbnail의 리턴이 bitmap이므로 Preview객체에 ThumbnailPreview:Bitmap을 추가하였음
2. 이미지를 썸네일로 불러올 때 AsyncTask로 불러오던 것을 RxKotlin을 이용하게 변경
3. 썸네일에 회전 적용