### PR TITLE
Use bitmap for thumbnail under android 10

### DIFF
--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/Preview.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/Preview.kt
@@ -15,9 +15,9 @@ import java.util.*
 
 data class Preview(
         var originalImageUri: Uri, // 원래 이미지의 Uri. 그런데 저장이나 crop을 하면 바뀐 저장이 된 파일의 uri로 바뀜
-        var thumbnailImageUri: Uri? = null,
         var resultImageUri: Uri, // 저장 할 이미지의 Uri. 저장이나 crop을 최소 한번이라도 하면 쓸모 없어짐. 즉, 최초 저장할때만 쓸모있음.
-        var thumbnailBitmap: Bitmap? = null, // 썸네일용 비트맵, Android Q(10) 이상에서만 사용
+        var contentsUri: Uri? = null, //썸네일 비트맵을 뽑아내기 위한 contents:// Uri
+        var thumbnailBitmap: Bitmap? = null, //썸네일 비트맵
         var isSaved: Boolean,
 
         var _brightness: Int,
@@ -48,11 +48,13 @@ data class Preview(
         }
     }
 
-    constructor(originalImageUri: Uri, thumbnailImageURI: Uri?, thumbnailBitmap: Bitmap?, rotation: Int) :
-            this(originalImageUri, thumbnailImageURI, makeResultImageFile(), thumbnailBitmap,
+    constructor(originalImageUri: Uri, contentsUri: Uri? = null, thumbnailBitmap: Bitmap? = null, rotation: Int = ExifInterface.ORIENTATION_NORMAL) :
+            this(originalImageUri, makeResultImageFile(), contentsUri, thumbnailBitmap,
                     true, 0, 0, 0, 0) {
         this.rotation = rotation
     }
+
+    var rotation: Int? = null
 
     fun getBitmap(context: Context): Bitmap? {
         val path = originalImageUri.path
@@ -61,8 +63,6 @@ data class Preview(
                 .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
         return PreviewBitmapManager.previewImageUriToBitmap(this.originalImageUri, context, rotation)
     }
-
-    var rotation: Int? = null
 
     var brightness: Int
         get() = _brightness + EtcConstant.SeekBarPreviewBrightnessMax / 2   //시크바에 들어갈 값이 리턴됨 (0~512) 실제 brightness 는 -255~+255

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
@@ -1,7 +1,6 @@
 package com.tistory.deque.previewmaker.kotlin.model
 
 import android.content.Context
-import android.database.CursorIndexOutOfBoundsException
 import android.graphics.Bitmap
 import android.media.ExifInterface
 import android.net.Uri
@@ -21,88 +20,60 @@ import java.util.concurrent.TimeUnit
 
 class PreviewLoader(private val context: Context) {
 
-    companion object{
-        const val THUMBNAIL_GETTER_METHOD_CALL_COUNT_MAX = 3
-        const val THUMBNAIL_LOADING_DELAY_MILLISECONDS = 30L
+    companion object {
+        private const val THUMBNAIL_LOADING_DELAY_MILLISECONDS = 20L
     }
 
     private val thumbnailBitmapSize: Int = context.resources.run {
         (getDimension(R.dimen.thumbnail_item_image_width_height) * displayMetrics.density).toInt()
     }
+    private val thumbnailSize = Size(thumbnailBitmapSize, thumbnailBitmapSize)
+
+    fun loadPreview(previewPathList: ArrayList<String>): Observable<Preview> {
+        return Observable.zip(
+                previewPathList.toObservable().flatMap { getPreviewObservable(it) },
+                Observable.interval(THUMBNAIL_LOADING_DELAY_MILLISECONDS, TimeUnit.MILLISECONDS), // Time interval between each preview
+                BiFunction { t1: Preview, _: Long -> t1 }
+        )
+    }
 
     private fun getPreviewObservable(previewPath: String): Observable<Preview> {
         return Observable.fromCallable {
-            var thumbnailBitmap: Bitmap? = null
-            var thumbnailUri: Uri? = null
             val originalUri: Uri = Uri.fromFile(File(previewPath))
+            val contentsUri = previewPath.getUri(context.contentResolver) ?: originalUri
 
-            if (Build.VERSION.SDK_INT  >= Build.VERSION_CODES.Q) {
-                thumbnailBitmap = getThumbnailBitmapFromOriginalUri(context, previewPath)
-            } else {
-                thumbnailUri = getThumbnailUriFromOriginalUri(context, previewPath) ?: originalUri
-            }
             val rotation = try {
                 ExifInterface(previewPath).getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
             } catch (e: FileNotFoundException) {
                 ExifInterface.ORIENTATION_UNDEFINED
             }
 
-            return@fromCallable Preview(originalUri, thumbnailUri, thumbnailBitmap, rotation)
+            return@fromCallable Preview(
+                    originalUri,
+                    contentsUri = contentsUri,
+                    rotation = rotation,
+                    thumbnailBitmap = getThumbnailBitmap(contentsUri)
+            )
         }
     }
 
-    fun loadPreview(previewPathList: ArrayList<String>): Observable<Preview> {
-        return Observable.zip(
-                        previewPathList.toObservable().flatMap { getPreviewObservable(it) },
-                        Observable.interval(THUMBNAIL_LOADING_DELAY_MILLISECONDS, TimeUnit.MILLISECONDS),
-                        BiFunction { t1: Preview, _: Long -> t1 }
-                )
+    private fun getThumbnailBitmap(contentsUri: Uri): Bitmap? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            getThumbnailBitmapFromUri(contentsUri)
+        } else {
+            getThumbnailBitmapFromUriUnder29(contentsUri)
+        }?.copy(Bitmap.Config.RGB_565, true)
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
-    private fun getThumbnailBitmapFromOriginalUri(context: Context, imagePath: String): Bitmap? {
-        EzLogger.d("imagePath : $imagePath")
-        val imageUri = imagePath.getUri(context.contentResolver) ?: return null
-        EzLogger.d("original imageUri : $imageUri")
-        return context.contentResolver.loadThumbnail(imageUri, Size(thumbnailBitmapSize, thumbnailBitmapSize), null)
+    private fun getThumbnailBitmapFromUri(contentsUri: Uri): Bitmap? {
+        EzLogger.d("imageUri : $contentsUri")
+        return context.contentResolver.loadThumbnail(contentsUri, thumbnailSize, null)
     }
 
-    private fun getThumbnailUriFromOriginalUri(context: Context, imagePath: String): Uri? {
-        EzLogger.d("imagePath : $imagePath")
-
-        val selectedImageUri = imagePath.getUri(context.contentResolver) ?: return null
-        val rowId = (selectedImageUri.lastPathSegment) ?: return null
-        val rowIdLong: Long = rowId.toLongOrNull() ?: return null
-
-        EzLogger.d("original uri : $selectedImageUri , row ID : $rowIdLong")
-
-        return imageIdToThumbnail(context, rowIdLong, 0)
-    }
-
-    private fun imageIdToThumbnail(context: Context, imageId: Long, callCount: Int): Uri? {
-        if (callCount >= THUMBNAIL_GETTER_METHOD_CALL_COUNT_MAX) return null
-
-        val projection = arrayOf(MediaStore.Images.Thumbnails.DATA)
-        val contentResolver = context.contentResolver
-
-        try {
-            contentResolver.query(
-                    MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI,
-                    projection,
-                    MediaStore.Images.Thumbnails.IMAGE_ID + "=?",
-                    arrayOf(imageId.toString()),
-                    null)
-                    ?.use { thumbnailCursor ->
-                        return if (thumbnailCursor.moveToFirst()) {
-                            Uri.parse(thumbnailCursor.getString(thumbnailCursor.getColumnIndex(projection[0])))
-                        } else {
-                            MediaStore.Images.Thumbnails.getThumbnail(contentResolver, imageId, MediaStore.Images.Thumbnails.MINI_KIND, null)
-                            //EzLogger.d("No exist thumbnail, so make it")
-                            imageIdToThumbnail(context, imageId, callCount + 1)
-                        }
-                    } ?: return null
-        } catch (e: CursorIndexOutOfBoundsException) {
-            return null
-        }
+    private fun getThumbnailBitmapFromUriUnder29(contentsUri: Uri): Bitmap? {
+        val rowId = (contentsUri.lastPathSegment)?.toLongOrNull() ?: return null
+        EzLogger.d("imageUri : $contentsUri, rowId : $rowId")
+        return MediaStore.Images.Thumbnails.getThumbnail(context.contentResolver, rowId, MediaStore.Images.Thumbnails.MINI_KIND, null)
     }
 }

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -223,26 +223,24 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
         _startLoadingThumbnailEvent.value = previewPathList.size
 
         previewLoader = PreviewLoader(applicationContext).apply {
-            addDisposable(
-                    loadPreview(previewPathList)
-                            .subscribeOn(Schedulers.io())
-                            .observeOn(AndroidSchedulers.mainThread())
-                            .subscribeBy(
-                                    onNext = {
-                                        previewAdapterModel.addPreview(it)
-                                        _loadingFinishEachThumbnailEvent.call()
-                                        EzLogger.d("Thumbnail parsing success : $it")
-                                    },
-                                    onError = {
-                                        EzLogger.d("Load preview error : $it")
-                                    },
-                                    onComplete = {
-                                        _finishLoadingThumbnailEvent.call()
-                                    }
-                            )
+            addDisposable(loadPreview(previewPathList)
+                    .subscribeOn(Schedulers.io())
+                    .observeOn(AndroidSchedulers.mainThread())
+                    .subscribeBy(
+                            onNext = {
+                                previewAdapterModel.addPreview(it)
+                                _loadingFinishEachThumbnailEvent.call()
+                                EzLogger.d("Thumbnail parsing success : $it")
+                            },
+                            onError = {
+                                EzLogger.d("Load preview error : $it")
+                            },
+                            onComplete = {
+                                _finishLoadingThumbnailEvent.call()
+                            }
+                    )
             )
         }
-
     }
 
     inner class LoadingPreviewToCanvas(val context: Context, val preview: Preview) : AsyncTask<Void, Void, Preview>() {

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/PreviewThumbnailHolder.kt
@@ -1,30 +1,22 @@
 package com.tistory.deque.previewmaker.kotlin.previewedit
 
-import android.media.ExifInterface
 import androidx.recyclerview.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.tistory.deque.previewmaker.R
 import com.tistory.deque.previewmaker.kotlin.model.Preview
-import com.tistory.deque.previewmaker.kotlin.util.EzLogger
 import kotlinx.android.synthetic.main.kt_preview_thumbnail_item.view.*
 
-class PreviewThumbnailHolder(parent:ViewGroup): RecyclerView.ViewHolder(
-        LayoutInflater
-                .from(parent.context)
+class PreviewThumbnailHolder(parent: ViewGroup) : RecyclerView.ViewHolder(
+        LayoutInflater.from(parent.context)
                 .inflate(R.layout.kt_preview_thumbnail_item, parent, false)
-){
+) {
     fun onBind(item: Preview, position: Int, previewThumbnailClickListener: (Preview, Int) -> Unit) {
         itemView.run {
             item.thumbnailBitmap?.let {
                 preview_thumbnail_item_image_view.setImageBitmap(it)
             } ?: run {
-                when (item.rotation) {
-                    ExifInterface.ORIENTATION_ROTATE_90 -> preview_thumbnail_item_image_view.rotation = 90f
-                    ExifInterface.ORIENTATION_ROTATE_180 -> preview_thumbnail_item_image_view.rotation = 180f
-                    ExifInterface.ORIENTATION_ROTATE_270 -> preview_thumbnail_item_image_view.rotation = 270f
-                }
-                preview_thumbnail_item_image_view.setImageURI(item.thumbnailImageUri ?: return@onBind)
+                preview_thumbnail_item_image_view.setImageResource(R.drawable.ic_error_outline_black_24dp)
             }
             preview_thumbnail_item_layout.setOnClickListener {
                 previewThumbnailClickListener(item, position)

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/util/extension/UriPath.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/util/extension/UriPath.kt
@@ -13,7 +13,7 @@ import com.tistory.deque.previewmaker.kotlin.util.EzLogger
  * uri -> path : use Uri.getRealPath()
  *
  * 만약 path로 부터 file:///storage/emulated/0/Pictures/Preview%20Maker/PREVIEW_20190201151124479.png 과 같은 Uri를 얻어오고 싶을 때 -> Uri.fromFile(File(path))
- * 만약 paht로 부터 content:///media/external/images/media/24323.. 과 같은 Uri를 얻고 싶을 때 -> path.getUri(contentResolver)
+ * 만약 path로 부터 content:///media/external/images/media/24323.. 과 같은 Uri를 얻고 싶을 때 -> path.getUri(contentResolver)
  *
  * 만약 Uri가 file://로 시작하는 uri일때 path를 얻고 싶으면 -> Uri.path
  * 만약 Uri가 content://로 시작하는 Uri일때 path를 얻고 싶으면 -> Uri.getRealPath()
@@ -23,30 +23,32 @@ fun Uri.getRealPath(contentResolver: ContentResolver): String? {
     val proj = arrayOf(MediaStore.Images.Media.DATA)
 
     contentResolver.query(this, proj, null, null, null)?.use { cursor ->
-        cursor.moveToNext()
-        try {
+        return try {
+            cursor.moveToNext()
             val path = cursor.getString(cursor.getColumnIndex(MediaStore.MediaColumns.DATA))
             EzLogger.d("getRealPath(), from uri: $this, path : $path")
-            return path
+            path
         } catch (e: CursorIndexOutOfBoundsException) {
-            return null
+            null
         }
     }
-
     return null
-
 }
 
 fun String.getUri(contentResolver: ContentResolver): Uri? {
-    contentResolver.query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, "_data = '$this'", null, null)?.use { cursor ->
-        try {
+    val selection: String = if (this.contains("'")) {
+        """_data = "$this""""
+    } else {
+        "_data = '$this'"
+    }
+    contentResolver.query(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, null, selection, null, null)?.use { cursor ->
+        return try {
             cursor.moveToNext()
             val id = cursor.getInt(cursor.getColumnIndex("_id"))
-            return ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id.toLong())
+            ContentUris.withAppendedId(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, id.toLong())
         } catch (e: CursorIndexOutOfBoundsException) {
-            return null
+            null
         }
     }
-
     return null
 }

--- a/app/src/main/res/drawable/ic_error_outline_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_error_outline_black_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FF4081"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+</vector>


### PR DESCRIPTION
### 변경사항
1. 안드로이드 10 미만에서도 썸네일로 비트맵 사용
2. 썸네일 비트맵의 메모리를 줄이기 위해 RGB.555로 카피하여 사용 