### PR TITLE
Fix crash when file is not found

### DIFF
--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/PreviewBitmapManager.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/PreviewBitmapManager.kt
@@ -121,24 +121,16 @@ object PreviewBitmapManager {
         EzLogger.d("getResizedBitmapElements canvas w, h : $canvasWidth, $canvasHeight")
 
         if (bitmapRate >= canvasRate && previewBitmapWidth >= canvasWidth) { // w > h
-            EzLogger.d("getResizedBitmapElements case 1")
-
             changedPreviewPosWidth = 0
             changedPreviewPosHeight = (canvasHeight - (canvasWidth * (1 / bitmapRate)).toInt()) / 2
             changedPreviewBitmapWidth = canvasWidth
             changedPreviewBitmapHeight = (canvasWidth * (1 / bitmapRate)).toInt()
-
         } else if (bitmapRate < canvasRate && previewBitmapHeight >= canvasHeight) { // w < h
-            EzLogger.d("getResizedBitmapElements case 2")
-
             changedPreviewPosWidth = (canvasWidth - (canvasHeight * bitmapRate).toInt()) / 2
             changedPreviewPosHeight = 0
             changedPreviewBitmapWidth = (canvasHeight * bitmapRate).toInt()
             changedPreviewBitmapHeight = canvasHeight
-
         } else {
-            EzLogger.d("getResizedBitmapElements case 3")
-
             changedPreviewPosWidth = (canvasWidth - previewBitmapWidth) / 2
             changedPreviewPosHeight = (canvasHeight - previewBitmapHeight) / 2
             changedPreviewBitmapWidth = previewBitmapWidth

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/Preview.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/Preview.kt
@@ -9,6 +9,7 @@ import com.tistory.deque.previewmaker.kotlin.manager.PreviewBitmapManager
 import com.tistory.deque.previewmaker.kotlin.util.EtcConstant
 import com.tistory.deque.previewmaker.kotlin.util.EzLogger
 import java.io.File
+import java.io.IOException
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -59,9 +60,13 @@ data class Preview(
     fun getBitmap(context: Context): Bitmap? {
         val path = originalImageUri.path
         EzLogger.d("Preview.kt, getBitmap(), originalImageUri : $originalImageUri, path : $path")
-        val rotation = ExifInterface(path ?: return null)
-                .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
-        return PreviewBitmapManager.previewImageUriToBitmap(this.originalImageUri, context, rotation)
+        return try {
+            val rotation = ExifInterface(path ?: return null)
+                    .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)
+            PreviewBitmapManager.previewImageUriToBitmap(this.originalImageUri, context, rotation)
+        } catch (e: IOException) {
+            throw e
+        }
     }
 
     var brightness: Int

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/model/PreviewLoader.kt
@@ -17,6 +17,7 @@ import io.reactivex.functions.BiFunction
 import io.reactivex.rxkotlin.toObservable
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 object PreviewLoader {
@@ -42,11 +43,18 @@ object PreviewLoader {
         return Observable.zip(
                 Observable.fromCallable {
                     if (PreviewBitmapManager.selectedStampBitmap == null) {
-                        PreviewBitmapManager.selectedStampBitmap = PreviewBitmapManager.stampImageUriToBitmap(stamp?.imageUri ?: return@fromCallable null, context)
+                        PreviewBitmapManager.selectedStampBitmap = PreviewBitmapManager.stampImageUriToBitmap(stamp?.imageUri
+                                ?: return@fromCallable null, context)
                     }
                     return@fromCallable PreviewBitmapManager.selectedStampBitmap
                 },
-                Observable.just(preview.getBitmap(context)),
+                Observable.fromCallable {
+                    try {
+                        return@fromCallable preview.getBitmap(context)
+                    } catch(e: IOException) {
+                        error(context.getString(R.string.error_might_file_not_found))
+                    }
+                },
                 BiFunction { _, previewBitmap -> previewBitmap }
         )
     }

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
@@ -84,7 +84,6 @@ class KtPreviewEditActivity : BaseKotlinActivity<KtPreviewEditViewModel>() {
     }
 
     private fun previewThumbnailClickListener(preview: Preview, position: Int) {
-        EzLogger.d("previewThumbnailAdapter previewThumbnailClickListener")
         viewModel.previewThumbnailClickListener(this, preview, position)
     }
 

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -234,6 +234,10 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
                         },
                         onError = {
                             EzLogger.d("Load preview to canvas error : $it")
+                            showSnackbar(it.message.toString())
+                            selectedPreview = null
+                            _initCanvasAndPreviewEvent.call()
+                            _finishLoadingPreviewToCanvas.call()
                         }
                 ))
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,5 +83,5 @@
     <string name="message_blurring_bitmap_dialog">블러를 적용 중입니다.</string>
     <string name="snackbar_main_stamp_source_not_exist">선택된 낙관이 없습니다.</string>
 
-
+    <string name="error_might_file_not_found">파일을 찾을 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
### 문제
파일을 불러온 다음 그 파일을 지우거나 옮기면 FileNotFoundException 발생

### 해결
IOException이 catch되면 onError를 호출하고 error에 파일을 찾을 수 없다는 메세지를 담음
그 후 onError에서는 토스트를 띄우고 selectedPreview를 null로 초기화
selectedPreview는 null이 되어도 null check가 잘 되어 있기 때문에 사진 편집 상태가 자연스럽게 초기화 됨