### PR TITLE
Fix IllegalStateException when bitmap is not mutable

### DIFF
--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/BlurManager.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/BlurManager.kt
@@ -34,6 +34,24 @@ object BlurManager {
     var ovalRectFRightForSave:Double = 0.0
     var ovalRectFBottomForSave:Double = 0.0
 
+    init {
+        resetManager()
+    }
+
+    fun resetManager() {
+        guideOvalRectFLeft = 0.0f
+        guideOvalRectFTop = 0.0f
+        guideOvalRectFRight = 0.0f
+        guideOvalRectFBottom = 0.0f
+        guideOvalRectFLeftOrig = 0.0f
+        guideOvalRectFTopOrig = 0.0f
+        guideOvalRectFRightOrig = 0.0f
+        guideOvalRectFBottomOrig = 0.0f
+        ovalRectFLeftForSave = 0.0
+        ovalRectFTopForSave = 0.0
+        ovalRectFRightForSave = 0.0
+        ovalRectFBottomForSave = 0.0
+    }
 
     fun resetGuideOvalRectF(left: Float, top: Float) {
         setGuideOvalRectFLeftTop(left, top)
@@ -205,7 +223,10 @@ object BlurManager {
 
         val width = Math.round(sentBitmap.width * scale)
         val height = Math.round(sentBitmap.height * scale)
-        val bitmap = Bitmap.createScaledBitmap(sentBitmap, width, height, false)
+        val bitmap = Bitmap.createScaledBitmap(sentBitmap, width, height, false).let {
+            if (it.isMutable) it
+            else it.copy(it.config, true)
+        }
 
         val w = bitmap.width
         val h = bitmap.height

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
@@ -10,6 +10,7 @@ import android.view.View
 import com.tistory.deque.previewmaker.R
 import com.tistory.deque.previewmaker.kotlin.base.BaseKotlinActivity
 import com.tistory.deque.previewmaker.kotlin.helppreviewedit.KtHelpPreviewEditActivity
+import com.tistory.deque.previewmaker.kotlin.manager.BlurManager
 import com.tistory.deque.previewmaker.kotlin.manager.PreviewBitmapManager
 import com.tistory.deque.previewmaker.kotlin.model.Preview
 import com.tistory.deque.previewmaker.kotlin.model.Stamp
@@ -181,6 +182,7 @@ class KtPreviewEditActivity : BaseKotlinActivity<KtPreviewEditViewModel>() {
 
     override fun onDestroy() {
         PreviewBitmapManager.resetManager()
+        BlurManager.resetManager()
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -251,7 +251,8 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
                             _finishLoadingPreviewToBlur.call()
                         },
                         onError = {
-                            EzLogger.d("Blur error : $it")
+                            EzLogger.d("Blur error : ${it.printStackTrace()}")
+                            _finishLoadingPreviewToBlur.call()
                         }
                 ))
     }


### PR DESCRIPTION
### 문제
비트맵을 createScaledBitmap을 통해 얻어올 때 소스 비트맵이 not mutable이면 createScaledBitmap의 리턴 비트맵도 not mutable이라서 IllegalStateException이 발생함

### 해결
createScaledBitmap로 얻어온 비트맵이 not mutable일 경우 copy를 통해 재 생성