### PR TITLE
Set crop max size, save previous crop ratio

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.tistory.deque.previewmaker">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:name=".kotlin.PreviewMakerApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -13,7 +15,8 @@
         android:largeHeap="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:targetApi="q">
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/makestamp/KtMakeStampViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/makestamp/KtMakeStampViewModel.kt
@@ -11,6 +11,7 @@ import com.tistory.deque.previewmaker.R
 import com.tistory.deque.previewmaker.kotlin.base.BaseKotlinViewModel
 import com.tistory.deque.previewmaker.kotlin.manager.FilePathManager
 import com.tistory.deque.previewmaker.kotlin.util.EtcConstant
+import com.tistory.deque.previewmaker.kotlin.util.EtcConstant.STAMP_FILE_MAX_SIZE
 import com.tistory.deque.previewmaker.kotlin.util.EzLogger
 import com.tistory.deque.previewmaker.kotlin.util.SingleLiveEvent
 import com.tistory.deque.previewmaker.kotlin.util.extension.getRealPath
@@ -124,7 +125,7 @@ class KtMakeStampViewModel : BaseKotlinViewModel() {
     private fun checkStampSizeValid(contentResolver: ContentResolver): Boolean {
         try {
             val bitmap = MediaStore.Images.Media.getBitmap(contentResolver, stampSourceUri)
-            if (bitmap.height >= 2000 || bitmap.width >= 2000) {
+            if (bitmap.height >= STAMP_FILE_MAX_SIZE || bitmap.width >= STAMP_FILE_MAX_SIZE) {
                 EzLogger.d("SIZE OVER")
                 showSnackbar(R.string.snackbar_main_acti_stamp_size_over_err)
                 return false

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/PreviewBitmapManager.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/PreviewBitmapManager.kt
@@ -7,18 +7,15 @@ import com.tistory.deque.previewmaker.kotlin.util.EzLogger
 import java.io.FileNotFoundException
 import java.io.IOException
 import android.media.ExifInterface
-import android.R.attr.orientation
 import android.graphics.*
+import com.tistory.deque.previewmaker.kotlin.util.EtcConstant.PREVIEW_BITMAP_MAX_SIZE_DEFAULT
+import com.tistory.deque.previewmaker.kotlin.util.EtcConstant.STAMP_BITMAP_MAX_SIZE
 import io.reactivex.Single
-import java.lang.IllegalArgumentException
 import java.util.ArrayList
 import kotlin.math.roundToInt
 
 
 object PreviewBitmapManager {
-    private const val previewBitmapMaxSize = 2000
-    private const val stampBitmapMaxSize = 1000
-
     var selectedPreviewBitmap: Bitmap? = null
     var selectedStampBitmap: Bitmap? = null
     var blurredPreviewBitmap: Bitmap? = null
@@ -31,11 +28,11 @@ object PreviewBitmapManager {
     }
 
     fun stampImageUriToBitmap(imageUri: Uri, context: Context): Bitmap? {
-        return imageUriToBitmap(stampBitmapMaxSize, imageUri, context, null)
+        return imageUriToBitmap(STAMP_BITMAP_MAX_SIZE, imageUri, context, null)
     }
 
     fun previewImageUriToBitmap(imageUri: Uri, context: Context, rotation: Int?): Bitmap? {
-        return imageUriToBitmap(previewBitmapMaxSize, imageUri, context, rotation)
+        return imageUriToBitmap(PREVIEW_BITMAP_MAX_SIZE_DEFAULT, imageUri, context, rotation)
     }
 
     private fun imageUriToBitmap(maxSize: Int, imageUri: Uri, context: Context, rotation: Int?): Bitmap? {
@@ -165,28 +162,15 @@ object PreviewBitmapManager {
      * @param bottom
      */
     private fun blurBitmap(partOvalElements: ArrayList<Double>) {
-        val left: Int
-        val top: Int
-        val right: Int
-        val bottom: Int
-        val ovalLeft: Int
-        val ovalTop: Int
-        val ovalRight: Int
-        val ovalBottom: Int
-        try {
-            left = partOvalElements[0].roundToInt()
-            top = partOvalElements[1].roundToInt()
-            right = partOvalElements[2].roundToInt()
-            bottom = partOvalElements[3].roundToInt()
-            ovalLeft = partOvalElements[4].roundToInt()
-            ovalTop = partOvalElements[5].roundToInt()
-            ovalRight = partOvalElements[6].roundToInt()
-            ovalBottom = partOvalElements[7].roundToInt()
-            BlurManager.setBlurOrigRect(partOvalElements[0], partOvalElements[1], partOvalElements[2], partOvalElements[3])
-        } catch (e: IllegalArgumentException) {
-            e.printStackTrace()
-            return
-        }
+        val left: Int = partOvalElements[0].roundToInt()
+        val top: Int = partOvalElements[1].roundToInt()
+        val right: Int = partOvalElements[2].roundToInt()
+        val bottom: Int = partOvalElements[3].roundToInt()
+        val ovalLeft: Int = partOvalElements[4].roundToInt()
+        val ovalTop: Int = partOvalElements[5].roundToInt()
+        val ovalRight: Int = partOvalElements[6].roundToInt()
+        val ovalBottom: Int = partOvalElements[7].roundToInt()
+        BlurManager.setBlurOrigRect(partOvalElements[0], partOvalElements[1], partOvalElements[2], partOvalElements[3])
 
         BlurManager.doFastBlur(
                 Bitmap.createBitmap(selectedPreviewBitmap

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/SharedPreferencesManager.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/manager/SharedPreferencesManager.kt
@@ -8,6 +8,7 @@ object SharedPreferencesManager {
     private const val SHARED_PREFERENCES_NAME = "PREVIEW_MAKER_PREFERENCES"
 
     private const val STAMP_HIDDEN_ENABLED = "STAMP_HIDDEN_ENABLED"
+    private const val PREVIEW_WIDTH_OVER_HEIGHT_RATIO = "PREVIEW_WIDTH_OVER_HEIGHT_RATIO" // width/height ratio
 
     private var mPref: SharedPreferences? = null
 
@@ -23,4 +24,13 @@ object SharedPreferencesManager {
     fun getStampHiddenEnabled(context: Context): Boolean {
         return getPref(context).getBoolean(STAMP_HIDDEN_ENABLED, true)
     }
+
+    fun setPreviewWidthOverHeightRatio(context: Context, widthOverHeight: Float) {
+        getPref(context).edit().putFloat(PREVIEW_WIDTH_OVER_HEIGHT_RATIO, widthOverHeight).apply()
+    }
+
+    fun getPreviewWidthOverHeightRatio(context: Context): Float {
+        return getPref(context).getFloat(PREVIEW_WIDTH_OVER_HEIGHT_RATIO, 1.5f)
+    }
+
 }

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditActivity.kt
@@ -13,6 +13,7 @@ import com.tistory.deque.previewmaker.kotlin.helppreviewedit.KtHelpPreviewEditAc
 import com.tistory.deque.previewmaker.kotlin.manager.BlurManager
 import com.tistory.deque.previewmaker.kotlin.manager.PreviewBitmapManager
 import com.tistory.deque.previewmaker.kotlin.manager.PreviewEditClickStateManager
+import com.tistory.deque.previewmaker.kotlin.manager.SharedPreferencesManager
 import com.tistory.deque.previewmaker.kotlin.model.Preview
 import com.tistory.deque.previewmaker.kotlin.model.Stamp
 import com.tistory.deque.previewmaker.kotlin.util.EtcConstant
@@ -156,6 +157,11 @@ class KtPreviewEditActivity : BaseKotlinActivity<KtPreviewEditViewModel>() {
         if (resultCode == RESULT_OK && requestCode == UCrop.REQUEST_CROP) {
             data?.let {
                 val resultUri = UCrop.getOutput(it) ?: return@let
+
+                val cropAspectRatio = UCrop.getOutputCropAspectRatio(it)
+                if (cropAspectRatio > 0f) {
+                    SharedPreferencesManager.setPreviewWidthOverHeightRatio(applicationContext, cropAspectRatio)
+                }
 
                 val mediaScanIntent = Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE)
                 mediaScanIntent.data = resultUri

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -156,7 +156,7 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
 
     fun cropSelectedPreview(activity: KtPreviewEditActivity) {
         selectedPreview?.let {
-            val options: UCrop.Options = setCropViewOption(activity)
+            val options: UCrop.Options = setUCropViewOption(activity)
 
             UCrop.of(it.originalImageUri, it.resultImageUri)
                     .withOptions(options)
@@ -166,24 +166,22 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
         }
     }
 
-    private fun setCropViewOption(context: Context): UCrop.Options {
-        val options = UCrop.Options()
-        options.setToolbarColor(ContextCompat.getColor(context, R.color.colorPrimary))
-        options.setActiveWidgetColor(ContextCompat.getColor(context, R.color.colorAccent))
-        options.setToolbarWidgetColor(ContextCompat.getColor(context, R.color.black))
-        options.setStatusBarColor(ContextCompat.getColor(context, R.color.colorPrimaryDark))
-        options.setFreeStyleCropEnabled(true)
-
-        options.setAspectRatioOptions(1,
-                AspectRatio("16:9", 16f, 9f),
-                AspectRatio("3:2", 3f, 2f),
-                AspectRatio("ORIGINAL", CropImageView.DEFAULT_ASPECT_RATIO, CropImageView.DEFAULT_ASPECT_RATIO),
-                AspectRatio("1:1", 1f, 1f),
-                AspectRatio("2:3", 2f, 3f),
-                AspectRatio("9:16", 9f, 16f)
-        )
-
-        return options
+    private fun setUCropViewOption(context: Context): UCrop.Options {
+        return UCrop.Options().apply {
+            setToolbarColor(ContextCompat.getColor(context, R.color.colorPrimary))
+            setActiveWidgetColor(ContextCompat.getColor(context, R.color.colorAccent))
+            setToolbarWidgetColor(ContextCompat.getColor(context, R.color.black))
+            setStatusBarColor(ContextCompat.getColor(context, R.color.colorPrimaryDark))
+            setFreeStyleCropEnabled(true)
+            setAspectRatioOptions(1,
+                    AspectRatio("16:9", 16f, 9f),
+                    AspectRatio("3:2", 3f, 2f),
+                    AspectRatio("ORIGINAL", CropImageView.DEFAULT_ASPECT_RATIO, CropImageView.DEFAULT_ASPECT_RATIO),
+                    AspectRatio("1:1", 1f, 1f),
+                    AspectRatio("2:3", 2f, 3f),
+                    AspectRatio("9:16", 9f, 16f))
+            setMaxBitmapSize(EtcConstant.UCROP_MAX_BITMAP_SIZE)
+        }
     }
 
     fun dbUpdateStamp(id: Int, stamp: Stamp) {
@@ -252,6 +250,7 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
                         },
                         onError = {
                             EzLogger.d("Blur error : ${it.printStackTrace()}")
+                            showSnackbar(R.string.blur_error_toast_text)
                             _finishLoadingPreviewToBlur.call()
                         }
                 ))

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/previewedit/KtPreviewEditViewModel.kt
@@ -10,6 +10,7 @@ import com.tistory.deque.previewmaker.kotlin.base.BaseKotlinViewModel
 import com.tistory.deque.previewmaker.kotlin.db.KtDbOpenHelper
 import com.tistory.deque.previewmaker.kotlin.manager.PreviewBitmapManager
 import com.tistory.deque.previewmaker.kotlin.manager.PreviewEditButtonViewStateManager
+import com.tistory.deque.previewmaker.kotlin.manager.SharedPreferencesManager
 import com.tistory.deque.previewmaker.kotlin.model.Preview
 import com.tistory.deque.previewmaker.kotlin.model.PreviewAdapterModel
 import com.tistory.deque.previewmaker.kotlin.model.PreviewLoader
@@ -128,7 +129,6 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
         if (previewAdapterModel.size <= 1) return
         selectedPreviewPosition?.let {
             previewAdapterModel.delete(it)
-            //_previewThumbnailAdapterRemovePosition.value = it
             _previewThumbnailAdapterNotifyDataSet.call()
 
             // 보여줄 프리뷰 포지션 변경
@@ -167,16 +167,19 @@ class KtPreviewEditViewModel : BaseKotlinViewModel() {
     }
 
     private fun setUCropViewOption(context: Context): UCrop.Options {
+        val widthOverHeight = SharedPreferencesManager.getPreviewWidthOverHeightRatio(context)
+
         return UCrop.Options().apply {
             setToolbarColor(ContextCompat.getColor(context, R.color.colorPrimary))
             setActiveWidgetColor(ContextCompat.getColor(context, R.color.colorAccent))
             setToolbarWidgetColor(ContextCompat.getColor(context, R.color.black))
             setStatusBarColor(ContextCompat.getColor(context, R.color.colorPrimaryDark))
             setFreeStyleCropEnabled(true)
-            setAspectRatioOptions(1,
+            setAspectRatioOptions(3,
                     AspectRatio("16:9", 16f, 9f),
                     AspectRatio("3:2", 3f, 2f),
-                    AspectRatio("ORIGINAL", CropImageView.DEFAULT_ASPECT_RATIO, CropImageView.DEFAULT_ASPECT_RATIO),
+                    AspectRatio("ORIGIN", CropImageView.DEFAULT_ASPECT_RATIO, CropImageView.DEFAULT_ASPECT_RATIO),
+                    AspectRatio("PREV", widthOverHeight, 1f),
                     AspectRatio("1:1", 1f, 1f),
                     AspectRatio("2:3", 2f, 3f),
                     AspectRatio("9:16", 9f, 16f))

--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/util/EtcConstant.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/util/EtcConstant.kt
@@ -22,4 +22,9 @@ object EtcConstant{
     const val SeekBarPreviewContrastMax = 512
     const val SeekBarPreviewSaturationMax = 512
     const val SeekBarPreviewKelvinMax = 512
+
+    const val UCROP_MAX_BITMAP_SIZE = 10000
+    const val PREVIEW_BITMAP_MAX_SIZE_DEFAULT = 2500
+    const val STAMP_BITMAP_MAX_SIZE = 1000
+    const val STAMP_FILE_MAX_SIZE = 2000
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,7 @@
 
     <string name="guide_select_previews">프리뷰로 편집할 사진을 선택해주세요</string>
 
+    <string name="blur_error_toast_text">블러 수행 중 에러가 발생하였습니다.</string>
 
     <string name="canvasview_hint">편집할 프리뷰를 상단에서 선택해 주세요</string>
 


### PR DESCRIPTION
### 변경사항
1. 크롭시 맥스 사이즈를 아주 크게 주어야 작은 이미지로 크롭이 안됨. 
    * uCrop 로직상 원본 이미지의 가로/세로 크기로 이미지를 저장하는게 아니고, 대각선 길이를 구한 다음 그것을 다시 가로/세로 길이의 max로 활용하기 때문에 따로 max 값을 세팅하지 않으면 작은 이미지가 디폴트로 설정이 됨

2. 크롭시 이전에 설정했던 사이즈 ratio를 preferences에 저장하고 그것을 다음 크롭 시 불러오게 변경 