### PR TITLE
Fix finishing setting activity when user click "not save"

### DIFF
--- a/app/src/main/java/com/tistory/deque/previewmaker/kotlin/setting/KtSettingActivity.kt
+++ b/app/src/main/java/com/tistory/deque/previewmaker/kotlin/setting/KtSettingActivity.kt
@@ -80,6 +80,7 @@ class KtSettingActivity : BaseKotlinActivity<KtSettingViewModel>() {
                     }
                     .setNegativeButton(R.string.setting_save_dialog_negative_text) { dialog, _ ->
                         dialog.dismiss()
+                        finish()
                     }
                     .show()
         } else {


### PR DESCRIPTION
### 변경사항

설정에서 뒤로가거나 백키를 클릭했을 때 나오는 Dialog에서
"아니요"를 눌렸을 때, 설정 액티비티가 종료되지 않는 문제 해결